### PR TITLE
feat(fine-tuning): bump the transformer to the latest version

### DIFF
--- a/build/fine-tuning/requirements.txt
+++ b/build/fine-tuning/requirements.txt
@@ -1,4 +1,4 @@
-transformers==4.38.1
+transformers==4.46.3
 torch
 # TODO(kenji): Fix. This installs bitsandbytes compiled without GPU support.
 bitsandbytes


### PR DESCRIPTION
Getting the following error:

ImportError: cannot import name 'is_torch_mlu_available' from 'transformers.utils' (/usr/local/lib/python3.12/site-packages/transformers/utils/__init__.py). Did you mean: 'is_torch_mps_available'?