### PR TITLE
feat(fine-tuning): install autoawq

### DIFF
--- a/build/fine-tuning/requirements.txt
+++ b/build/fine-tuning/requirements.txt
@@ -9,3 +9,4 @@ trl
 peft
 gguf
 wandb
+autoawq


### PR DESCRIPTION
This library is required when an AWQ quantized model is loaded.