### PR TITLE
fix(dispatcher): set distinct names to the controllers

### DIFF
--- a/dispatcher/internal/dispatcher/batchjob.go
+++ b/dispatcher/internal/dispatcher/batchjob.go
@@ -106,6 +106,7 @@ func (m *BatchJobManager) SetupWithManager(mgr ctrl.Manager) error {
 		return isManagedBatchJob(object.GetAnnotations())
 	}))
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("batchjob").
 		For(&batchv1.Job{}, builder.WithPredicates(filterByAnno)).
 		WithLogConstructor(func(r *reconcile.Request) logr.Logger {
 			if r != nil {

--- a/dispatcher/internal/dispatcher/lifecycle_manager.go
+++ b/dispatcher/internal/dispatcher/lifecycle_manager.go
@@ -59,6 +59,7 @@ func (s *LifecycleManager) SetupWithManager(mgr ctrl.Manager) error {
 		return isManagedJob(object.GetAnnotations())
 	}))
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("ftjobs").
 		For(&batchv1.Job{}, builder.WithPredicates(filterByAnno)).
 		WithLogConstructor(func(r *reconcile.Request) logr.Logger {
 			if r != nil {

--- a/dispatcher/internal/dispatcher/notebook.go
+++ b/dispatcher/internal/dispatcher/notebook.go
@@ -75,6 +75,7 @@ func (n *NotebookManager) SetupWithManager(mgr ctrl.Manager) error {
 		return isManagedNotebook(object.GetAnnotations())
 	}))
 	return ctrl.NewControllerManagedBy(mgr).
+		Named("notebook").
 		For(&appsv1.Deployment{}, builder.WithPredicates(filterByAnno)).
 		WithLogConstructor(func(r *reconcile.Request) logr.Logger {
 			if r != nil {


### PR DESCRIPTION
This fixes a crash with the following error message:

Error: controller with name job already exists. Controller names must be unique to avoid multiple controllers reporting to the same metric