### PR TITLE
fix: register the HTTP handler for /v1/jobs

### DIFF
--- a/server/cmd/run.go
+++ b/server/cmd/run.go
@@ -96,6 +96,9 @@ func run(ctx context.Context, c *config.Config) error {
 	if err := v1.RegisterBatchServiceHandlerFromEndpoint(ctx, mux, addr, opts); err != nil {
 		return err
 	}
+	if err := v1.RegisterJobServiceHandlerFromEndpoint(ctx, mux, addr, opts); err != nil {
+		return err
+	}
 
 	errCh := make(chan error)
 	go func() {


### PR DESCRIPTION
Add a missing call of RegisterJobServiceHandlerFromEndpoint