### PR TITLE
Generate TypeScript files from the protobuf with the `use_proto_names…

### DIFF
--- a/buf.gen.ts.yaml
+++ b/buf.gen.ts.yaml
@@ -2,3 +2,5 @@ version: v1
 plugins:
 - name: grpc-gateway-ts
   out: ./ts
+  opt:
+  - use_proto_names=true

--- a/buf.lock
+++ b/buf.lock
@@ -5,3 +5,4 @@ deps:
     owner: googleapis
     repository: googleapis
     commit: 546238c53f7340c6a2a6099fb863bc1b
+    digest: shake256:8d75c12f391e392b24c076d05117b47aeddb090add99c70247a8f4389b906a65f61a933c68e54ed8b73a050b967b6b712ba194348b67c3ab3ee26cc2cb25852c

--- a/dist/api/v1/batch_service.pb.d.ts
+++ b/dist/api/v1/batch_service.pb.d.ts
@@ -27,7 +27,7 @@ export type BatchJobError = {
     message?: string;
 };
 export type BatchJobResources = {
-    gpuCount?: number;
+    gpu_count?: number;
 };
 type BaseBatchJobKind = {};
 export type BatchJobKind = BaseBatchJobKind & OneOf<{
@@ -35,8 +35,8 @@ export type BatchJobKind = BaseBatchJobKind & OneOf<{
 }>;
 export type BatchJob = {
     id?: string;
-    createdAt?: string;
-    finishedAt?: string;
+    created_at?: string;
+    finished_at?: string;
     error?: BatchJobError;
     status?: string;
     image?: string;
@@ -45,17 +45,17 @@ export type BatchJob = {
     envs?: {
         [key: string]: string;
     };
-    dataFiles?: string[];
-    projectId?: string;
-    kubernetesNamespace?: string;
-    clusterId?: string;
+    data_files?: string[];
+    project_id?: string;
+    kubernetes_namespace?: string;
+    cluster_id?: string;
     kind?: BatchJobKind;
-    organizationTitle?: string;
-    projectTitle?: string;
-    clusterName?: string;
+    organization_title?: string;
+    project_title?: string;
+    cluster_name?: string;
 };
 export type PyTorchJob = {
-    workerCount?: number;
+    worker_count?: number;
 };
 export type CreateBatchJobRequest = {
     image?: string;
@@ -67,7 +67,7 @@ export type CreateBatchJobRequest = {
     envs?: {
         [key: string]: string;
     };
-    dataFiles?: string[];
+    data_files?: string[];
     kind?: BatchJobKind;
 };
 export type ListBatchJobsRequest = {
@@ -76,7 +76,7 @@ export type ListBatchJobsRequest = {
 };
 export type ListBatchJobsResponse = {
     jobs?: BatchJob[];
-    hasMore?: boolean;
+    has_more?: boolean;
 };
 export type GetBatchJobRequest = {
     id?: string;
@@ -90,7 +90,7 @@ export type DeleteBatchJobRequest = {
 export type InternalBatchJob = {
     job?: BatchJob;
     state?: InternalBatchJobState;
-    queuedAction?: InternalBatchJobAction;
+    queued_action?: InternalBatchJobAction;
 };
 export type ListQueuedInternalBatchJobsRequest = {};
 export type ListQueuedInternalBatchJobsResponse = {

--- a/dist/api/v1/fine_tuning_service.pb.d.ts
+++ b/dist/api/v1/fine_tuning_service.pb.d.ts
@@ -37,45 +37,45 @@ export type JobError = {
     param?: string;
 };
 export type JobHyperparameters = {
-    batchSize?: number;
-    learningRateMultiplier?: number;
-    nEpochs?: number;
+    batch_size?: number;
+    learning_rate_multiplier?: number;
+    n_epochs?: number;
 };
 export type Job = {
     id?: string;
-    createdAt?: string;
+    created_at?: string;
     error?: JobError;
-    fineTunedModel?: string;
-    finishedAt?: string;
+    fine_tuned_model?: string;
+    finished_at?: string;
     hyperparameters?: JobHyperparameters;
     model?: string;
     object?: string;
-    organizationId?: string;
-    resultFiles?: string[];
+    organization_id?: string;
+    result_files?: string[];
     status?: string;
-    trainedTokens?: number;
-    trainingFile?: string;
-    validationFile?: string;
+    trained_tokens?: number;
+    training_file?: string;
+    validation_file?: string;
     integrations?: Integration[];
     seed?: number;
-    projectId?: string;
-    kubernetesNamespace?: string;
-    clusterId?: string;
-    organizationTitle?: string;
-    projectTitle?: string;
-    clusterName?: string;
+    project_id?: string;
+    kubernetes_namespace?: string;
+    cluster_id?: string;
+    organization_title?: string;
+    project_title?: string;
+    cluster_name?: string;
 };
 export type CreateJobRequestHyperparameters = {
-    batchSize?: number;
-    learningRateMultiplier?: number;
-    nEpochs?: number;
+    batch_size?: number;
+    learning_rate_multiplier?: number;
+    n_epochs?: number;
 };
 export type CreateJobRequest = {
     model?: string;
-    trainingFile?: string;
+    training_file?: string;
     hyperparameters?: CreateJobRequestHyperparameters;
     suffix?: string;
-    validationFile?: string;
+    validation_file?: string;
     integrations?: Integration[];
     seed?: number;
 };
@@ -86,7 +86,7 @@ export type ListJobsRequest = {
 export type ListJobsResponse = {
     object?: string;
     data?: Job[];
-    hasMore?: boolean;
+    has_more?: boolean;
 };
 export type GetJobRequest = {
     id?: string;
@@ -96,10 +96,10 @@ export type CancelJobRequest = {
 };
 export type InternalJob = {
     job?: Job;
-    outputModelId?: string;
+    output_model_id?: string;
     suffix?: string;
     state?: InternalJobState;
-    queuedAction?: InternalJobAction;
+    queued_action?: InternalJobAction;
 };
 export type ListQueuedInternalJobsRequest = {};
 export type ListQueuedInternalJobsResponse = {
@@ -112,7 +112,7 @@ export type UpdateJobPhaseRequest = {
     id?: string;
     phase?: UpdateJobPhaseRequestPhase;
     message?: string;
-    modelId?: string;
+    model_id?: string;
 };
 export type UpdateJobPhaseResponse = {};
 export declare class FineTuningService {

--- a/dist/api/v1/job_manager_server.pb.d.ts
+++ b/dist/api/v1/job_manager_server.pb.d.ts
@@ -1,16 +1,16 @@
 import * as fm from "../../fetch.pb";
 import * as LlmarinerJobsServerV1Job_manager_server_worker from "./job_manager_server_worker.pb";
 export type ClusterSummary = {
-    gpuCapacity?: number;
-    gpuAllocated?: number;
-    gpuPodCount?: number;
+    gpu_capacity?: number;
+    gpu_allocated?: number;
+    gpu_pod_count?: number;
 };
 export type Cluster = {
     id?: string;
     name?: string;
     status?: LlmarinerJobsServerV1Job_manager_server_worker.ClusterStatus;
     summary?: ClusterSummary;
-    lastUpdatedAt?: string;
+    last_updated_at?: string;
 };
 export type ListClustersRequest = {};
 export type ListClustersResponse = {

--- a/dist/api/v1/job_manager_server_worker.pb.d.ts
+++ b/dist/api/v1/job_manager_server_worker.pb.d.ts
@@ -1,24 +1,24 @@
 import * as fm from "../../fetch.pb";
 export type GpuNode = {
-    resourceName?: string;
-    allocatableCount?: number;
+    resource_name?: string;
+    allocatable_count?: number;
 };
 export type GpuPod = {
-    resourceName?: string;
-    allocatedCount?: number;
-    namespacedName?: string;
+    resource_name?: string;
+    allocated_count?: number;
+    namespaced_name?: string;
 };
 export type ProvisionableResource = {
-    instanceFamily?: string;
-    instanceType?: string;
+    instance_family?: string;
+    instance_type?: string;
 };
 export type ClusterStatus = {
-    gpuNodes?: GpuNode[];
-    provisionableResources?: ProvisionableResource[];
-    gpuPods?: GpuPod[];
+    gpu_nodes?: GpuNode[];
+    provisionable_resources?: ProvisionableResource[];
+    gpu_pods?: GpuPod[];
 };
 export type UpdateClusterStatusRequest = {
-    clusterStatus?: ClusterStatus;
+    cluster_status?: ClusterStatus;
 };
 export type UpdateClusterStatusResponse = {};
 export declare class JobWorkerService {

--- a/dist/api/v1/syncer_service.pb.d.ts
+++ b/dist/api/v1/syncer_service.pb.d.ts
@@ -1,27 +1,27 @@
 import * as fm from "../../fetch.pb";
 export type PatchKubernetesObjectRequestResources = {
-    gpuLimit?: number;
+    gpu_limit?: number;
 };
 export type PatchKubernetesObjectRequest = {
     namespace?: string;
     name?: string;
-    group?: string;
-    version?: string;
-    resource?: string;
+    Group?: string;
+    Version?: string;
+    Resource?: string;
     resources?: PatchKubernetesObjectRequestResources;
     data?: Uint8Array;
 };
 export type PatchKubernetesObjectResponse = {
-    clusterId?: string;
+    cluster_id?: string;
     uid?: string;
 };
 export type DeleteKubernetesObjectRequest = {
-    clusterId?: string;
+    cluster_id?: string;
     namespace?: string;
     name?: string;
-    group?: string;
-    version?: string;
-    resource?: string;
+    Group?: string;
+    Version?: string;
+    Resource?: string;
 };
 export type DeleteKubernetesObjectResponse = {};
 export type ListClusterIDsRequest = {};

--- a/dist/api/v1/workspace_service.pb.d.ts
+++ b/dist/api/v1/workspace_service.pb.d.ts
@@ -31,9 +31,9 @@ export type NotebookError = {
 export type Notebook = {
     id?: string;
     name?: string;
-    createdAt?: string;
-    startedAt?: string;
-    stoppedAt?: string;
+    created_at?: string;
+    started_at?: string;
+    stopped_at?: string;
     image?: string;
     resources?: Resources;
     envs?: {
@@ -42,23 +42,23 @@ export type Notebook = {
     error?: NotebookError;
     status?: string;
     token?: string;
-    projectId?: string;
-    organizationId?: string;
-    kubernetesNamespace?: string;
-    clusterId?: string;
-    organizationTitle?: string;
-    projectTitle?: string;
-    clusterName?: string;
+    project_id?: string;
+    organization_id?: string;
+    kubernetes_namespace?: string;
+    cluster_id?: string;
+    organization_title?: string;
+    project_title?: string;
+    cluster_name?: string;
 };
 export type ResourcesQuantity = {
     requests?: number;
     limits?: number;
 };
 export type Resources = {
-    cpuMilicore?: ResourcesQuantity;
-    memoryMegabytes?: ResourcesQuantity;
-    storageMegabytes?: ResourcesQuantity;
-    gpuCount?: number;
+    cpu_milicore?: ResourcesQuantity;
+    memory_megabytes?: ResourcesQuantity;
+    storage_megabytes?: ResourcesQuantity;
+    gpu_count?: number;
 };
 type BaseCreateNotebookRequestImage = {};
 export type CreateNotebookRequestImage = BaseCreateNotebookRequestImage & OneOf<{
@@ -79,7 +79,7 @@ export type ListNotebooksRequest = {
 };
 export type ListNotebooksResponse = {
     notebooks?: Notebook[];
-    hasMore?: boolean;
+    has_more?: boolean;
 };
 export type GetNotebookRequest = {
     id?: string;
@@ -97,7 +97,7 @@ export type StartNotebookRequest = {
 export type InternalNotebook = {
     notebook?: Notebook;
     state?: NotebookState;
-    queuedAction?: NotebookQueuedAction;
+    queued_action?: NotebookQueuedAction;
 };
 export type ListQueuedInternalNotebooksRequest = {};
 export type ListQueuedInternalNotebooksResponse = {

--- a/ts/api/v1/batch_service.pb.ts
+++ b/ts/api/v1/batch_service.pb.ts
@@ -38,7 +38,7 @@ export type BatchJobError = {
 }
 
 export type BatchJobResources = {
-  gpuCount?: number
+  gpu_count?: number
 }
 
 
@@ -50,26 +50,26 @@ export type BatchJobKind = BaseBatchJobKind
 
 export type BatchJob = {
   id?: string
-  createdAt?: string
-  finishedAt?: string
+  created_at?: string
+  finished_at?: string
   error?: BatchJobError
   status?: string
   image?: string
   command?: string
   resources?: BatchJobResources
   envs?: {[key: string]: string}
-  dataFiles?: string[]
-  projectId?: string
-  kubernetesNamespace?: string
-  clusterId?: string
+  data_files?: string[]
+  project_id?: string
+  kubernetes_namespace?: string
+  cluster_id?: string
   kind?: BatchJobKind
-  organizationTitle?: string
-  projectTitle?: string
-  clusterName?: string
+  organization_title?: string
+  project_title?: string
+  cluster_name?: string
 }
 
 export type PyTorchJob = {
-  workerCount?: number
+  worker_count?: number
 }
 
 export type CreateBatchJobRequest = {
@@ -78,7 +78,7 @@ export type CreateBatchJobRequest = {
   scripts?: {[key: string]: Uint8Array}
   resources?: BatchJobResources
   envs?: {[key: string]: string}
-  dataFiles?: string[]
+  data_files?: string[]
   kind?: BatchJobKind
 }
 
@@ -89,7 +89,7 @@ export type ListBatchJobsRequest = {
 
 export type ListBatchJobsResponse = {
   jobs?: BatchJob[]
-  hasMore?: boolean
+  has_more?: boolean
 }
 
 export type GetBatchJobRequest = {
@@ -107,7 +107,7 @@ export type DeleteBatchJobRequest = {
 export type InternalBatchJob = {
   job?: BatchJob
   state?: InternalBatchJobState
-  queuedAction?: InternalBatchJobAction
+  queued_action?: InternalBatchJobAction
 }
 
 export type ListQueuedInternalBatchJobsRequest = {

--- a/ts/api/v1/fine_tuning_service.pb.ts
+++ b/ts/api/v1/fine_tuning_service.pb.ts
@@ -50,48 +50,48 @@ export type JobError = {
 }
 
 export type JobHyperparameters = {
-  batchSize?: number
-  learningRateMultiplier?: number
-  nEpochs?: number
+  batch_size?: number
+  learning_rate_multiplier?: number
+  n_epochs?: number
 }
 
 export type Job = {
   id?: string
-  createdAt?: string
+  created_at?: string
   error?: JobError
-  fineTunedModel?: string
-  finishedAt?: string
+  fine_tuned_model?: string
+  finished_at?: string
   hyperparameters?: JobHyperparameters
   model?: string
   object?: string
-  organizationId?: string
-  resultFiles?: string[]
+  organization_id?: string
+  result_files?: string[]
   status?: string
-  trainedTokens?: number
-  trainingFile?: string
-  validationFile?: string
+  trained_tokens?: number
+  training_file?: string
+  validation_file?: string
   integrations?: Integration[]
   seed?: number
-  projectId?: string
-  kubernetesNamespace?: string
-  clusterId?: string
-  organizationTitle?: string
-  projectTitle?: string
-  clusterName?: string
+  project_id?: string
+  kubernetes_namespace?: string
+  cluster_id?: string
+  organization_title?: string
+  project_title?: string
+  cluster_name?: string
 }
 
 export type CreateJobRequestHyperparameters = {
-  batchSize?: number
-  learningRateMultiplier?: number
-  nEpochs?: number
+  batch_size?: number
+  learning_rate_multiplier?: number
+  n_epochs?: number
 }
 
 export type CreateJobRequest = {
   model?: string
-  trainingFile?: string
+  training_file?: string
   hyperparameters?: CreateJobRequestHyperparameters
   suffix?: string
-  validationFile?: string
+  validation_file?: string
   integrations?: Integration[]
   seed?: number
 }
@@ -104,7 +104,7 @@ export type ListJobsRequest = {
 export type ListJobsResponse = {
   object?: string
   data?: Job[]
-  hasMore?: boolean
+  has_more?: boolean
 }
 
 export type GetJobRequest = {
@@ -117,10 +117,10 @@ export type CancelJobRequest = {
 
 export type InternalJob = {
   job?: Job
-  outputModelId?: string
+  output_model_id?: string
   suffix?: string
   state?: InternalJobState
-  queuedAction?: InternalJobAction
+  queued_action?: InternalJobAction
 }
 
 export type ListQueuedInternalJobsRequest = {
@@ -138,7 +138,7 @@ export type UpdateJobPhaseRequest = {
   id?: string
   phase?: UpdateJobPhaseRequestPhase
   message?: string
-  modelId?: string
+  model_id?: string
 }
 
 export type UpdateJobPhaseResponse = {

--- a/ts/api/v1/job_manager_server.pb.ts
+++ b/ts/api/v1/job_manager_server.pb.ts
@@ -7,9 +7,9 @@
 import * as fm from "../../fetch.pb"
 import * as LlmarinerJobsServerV1Job_manager_server_worker from "./job_manager_server_worker.pb"
 export type ClusterSummary = {
-  gpuCapacity?: number
-  gpuAllocated?: number
-  gpuPodCount?: number
+  gpu_capacity?: number
+  gpu_allocated?: number
+  gpu_pod_count?: number
 }
 
 export type Cluster = {
@@ -17,7 +17,7 @@ export type Cluster = {
   name?: string
   status?: LlmarinerJobsServerV1Job_manager_server_worker.ClusterStatus
   summary?: ClusterSummary
-  lastUpdatedAt?: string
+  last_updated_at?: string
 }
 
 export type ListClustersRequest = {

--- a/ts/api/v1/job_manager_server_worker.pb.ts
+++ b/ts/api/v1/job_manager_server_worker.pb.ts
@@ -6,29 +6,29 @@
 
 import * as fm from "../../fetch.pb"
 export type GpuNode = {
-  resourceName?: string
-  allocatableCount?: number
+  resource_name?: string
+  allocatable_count?: number
 }
 
 export type GpuPod = {
-  resourceName?: string
-  allocatedCount?: number
-  namespacedName?: string
+  resource_name?: string
+  allocated_count?: number
+  namespaced_name?: string
 }
 
 export type ProvisionableResource = {
-  instanceFamily?: string
-  instanceType?: string
+  instance_family?: string
+  instance_type?: string
 }
 
 export type ClusterStatus = {
-  gpuNodes?: GpuNode[]
-  provisionableResources?: ProvisionableResource[]
-  gpuPods?: GpuPod[]
+  gpu_nodes?: GpuNode[]
+  provisionable_resources?: ProvisionableResource[]
+  gpu_pods?: GpuPod[]
 }
 
 export type UpdateClusterStatusRequest = {
-  clusterStatus?: ClusterStatus
+  cluster_status?: ClusterStatus
 }
 
 export type UpdateClusterStatusResponse = {

--- a/ts/api/v1/syncer_service.pb.ts
+++ b/ts/api/v1/syncer_service.pb.ts
@@ -6,31 +6,31 @@
 
 import * as fm from "../../fetch.pb"
 export type PatchKubernetesObjectRequestResources = {
-  gpuLimit?: number
+  gpu_limit?: number
 }
 
 export type PatchKubernetesObjectRequest = {
   namespace?: string
   name?: string
-  group?: string
-  version?: string
-  resource?: string
+  Group?: string
+  Version?: string
+  Resource?: string
   resources?: PatchKubernetesObjectRequestResources
   data?: Uint8Array
 }
 
 export type PatchKubernetesObjectResponse = {
-  clusterId?: string
+  cluster_id?: string
   uid?: string
 }
 
 export type DeleteKubernetesObjectRequest = {
-  clusterId?: string
+  cluster_id?: string
   namespace?: string
   name?: string
-  group?: string
-  version?: string
-  resource?: string
+  Group?: string
+  Version?: string
+  Resource?: string
 }
 
 export type DeleteKubernetesObjectResponse = {

--- a/ts/api/v1/workspace_service.pb.ts
+++ b/ts/api/v1/workspace_service.pb.ts
@@ -42,22 +42,22 @@ export type NotebookError = {
 export type Notebook = {
   id?: string
   name?: string
-  createdAt?: string
-  startedAt?: string
-  stoppedAt?: string
+  created_at?: string
+  started_at?: string
+  stopped_at?: string
   image?: string
   resources?: Resources
   envs?: {[key: string]: string}
   error?: NotebookError
   status?: string
   token?: string
-  projectId?: string
-  organizationId?: string
-  kubernetesNamespace?: string
-  clusterId?: string
-  organizationTitle?: string
-  projectTitle?: string
-  clusterName?: string
+  project_id?: string
+  organization_id?: string
+  kubernetes_namespace?: string
+  cluster_id?: string
+  organization_title?: string
+  project_title?: string
+  cluster_name?: string
 }
 
 export type ResourcesQuantity = {
@@ -66,10 +66,10 @@ export type ResourcesQuantity = {
 }
 
 export type Resources = {
-  cpuMilicore?: ResourcesQuantity
-  memoryMegabytes?: ResourcesQuantity
-  storageMegabytes?: ResourcesQuantity
-  gpuCount?: number
+  cpu_milicore?: ResourcesQuantity
+  memory_megabytes?: ResourcesQuantity
+  storage_megabytes?: ResourcesQuantity
+  gpu_count?: number
 }
 
 
@@ -93,7 +93,7 @@ export type ListNotebooksRequest = {
 
 export type ListNotebooksResponse = {
   notebooks?: Notebook[]
-  hasMore?: boolean
+  has_more?: boolean
 }
 
 export type GetNotebookRequest = {
@@ -118,7 +118,7 @@ export type StartNotebookRequest = {
 export type InternalNotebook = {
   notebook?: Notebook
   state?: NotebookState
-  queuedAction?: NotebookQueuedAction
+  queued_action?: NotebookQueuedAction
 }
 
 export type ListQueuedInternalNotebooksRequest = {

--- a/ts/google/api/http.pb.ts
+++ b/ts/google/api/http.pb.ts
@@ -14,15 +14,15 @@ type OneOf<T> =
     : never);
 export type Http = {
   rules?: HttpRule[]
-  fullyDecodeReservedExpansion?: boolean
+  fully_decode_reserved_expansion?: boolean
 }
 
 
 type BaseHttpRule = {
   selector?: string
   body?: string
-  responseBody?: string
-  additionalBindings?: HttpRule[]
+  response_body?: string
+  additional_bindings?: HttpRule[]
 }
 
 export type HttpRule = BaseHttpRule

--- a/ts/google/protobuf/descriptor.pb.ts
+++ b/ts/google/protobuf/descriptor.pb.ts
@@ -4,6 +4,26 @@
 * This file is a generated Typescript file for GRPC Gateway, DO NOT MODIFY
 */
 
+export enum Edition {
+  EDITION_UNKNOWN = "EDITION_UNKNOWN",
+  EDITION_LEGACY = "EDITION_LEGACY",
+  EDITION_PROTO2 = "EDITION_PROTO2",
+  EDITION_PROTO3 = "EDITION_PROTO3",
+  EDITION_2023 = "EDITION_2023",
+  EDITION_2024 = "EDITION_2024",
+  EDITION_1_TEST_ONLY = "EDITION_1_TEST_ONLY",
+  EDITION_2_TEST_ONLY = "EDITION_2_TEST_ONLY",
+  EDITION_99997_TEST_ONLY = "EDITION_99997_TEST_ONLY",
+  EDITION_99998_TEST_ONLY = "EDITION_99998_TEST_ONLY",
+  EDITION_99999_TEST_ONLY = "EDITION_99999_TEST_ONLY",
+  EDITION_MAX = "EDITION_MAX",
+}
+
+export enum ExtensionRangeOptionsVerificationState {
+  DECLARATION = "DECLARATION",
+  UNVERIFIED = "UNVERIFIED",
+}
+
 export enum FieldDescriptorProtoType {
   TYPE_DOUBLE = "TYPE_DOUBLE",
   TYPE_FLOAT = "TYPE_FLOAT",
@@ -27,8 +47,8 @@ export enum FieldDescriptorProtoType {
 
 export enum FieldDescriptorProtoLabel {
   LABEL_OPTIONAL = "LABEL_OPTIONAL",
-  LABEL_REQUIRED = "LABEL_REQUIRED",
   LABEL_REPEATED = "LABEL_REPEATED",
+  LABEL_REQUIRED = "LABEL_REQUIRED",
 }
 
 export enum FileOptionsOptimizeMode {
@@ -49,10 +69,72 @@ export enum FieldOptionsJSType {
   JS_NUMBER = "JS_NUMBER",
 }
 
+export enum FieldOptionsOptionRetention {
+  RETENTION_UNKNOWN = "RETENTION_UNKNOWN",
+  RETENTION_RUNTIME = "RETENTION_RUNTIME",
+  RETENTION_SOURCE = "RETENTION_SOURCE",
+}
+
+export enum FieldOptionsOptionTargetType {
+  TARGET_TYPE_UNKNOWN = "TARGET_TYPE_UNKNOWN",
+  TARGET_TYPE_FILE = "TARGET_TYPE_FILE",
+  TARGET_TYPE_EXTENSION_RANGE = "TARGET_TYPE_EXTENSION_RANGE",
+  TARGET_TYPE_MESSAGE = "TARGET_TYPE_MESSAGE",
+  TARGET_TYPE_FIELD = "TARGET_TYPE_FIELD",
+  TARGET_TYPE_ONEOF = "TARGET_TYPE_ONEOF",
+  TARGET_TYPE_ENUM = "TARGET_TYPE_ENUM",
+  TARGET_TYPE_ENUM_ENTRY = "TARGET_TYPE_ENUM_ENTRY",
+  TARGET_TYPE_SERVICE = "TARGET_TYPE_SERVICE",
+  TARGET_TYPE_METHOD = "TARGET_TYPE_METHOD",
+}
+
 export enum MethodOptionsIdempotencyLevel {
   IDEMPOTENCY_UNKNOWN = "IDEMPOTENCY_UNKNOWN",
   NO_SIDE_EFFECTS = "NO_SIDE_EFFECTS",
   IDEMPOTENT = "IDEMPOTENT",
+}
+
+export enum FeatureSetFieldPresence {
+  FIELD_PRESENCE_UNKNOWN = "FIELD_PRESENCE_UNKNOWN",
+  EXPLICIT = "EXPLICIT",
+  IMPLICIT = "IMPLICIT",
+  LEGACY_REQUIRED = "LEGACY_REQUIRED",
+}
+
+export enum FeatureSetEnumType {
+  ENUM_TYPE_UNKNOWN = "ENUM_TYPE_UNKNOWN",
+  OPEN = "OPEN",
+  CLOSED = "CLOSED",
+}
+
+export enum FeatureSetRepeatedFieldEncoding {
+  REPEATED_FIELD_ENCODING_UNKNOWN = "REPEATED_FIELD_ENCODING_UNKNOWN",
+  PACKED = "PACKED",
+  EXPANDED = "EXPANDED",
+}
+
+export enum FeatureSetUtf8Validation {
+  UTF8_VALIDATION_UNKNOWN = "UTF8_VALIDATION_UNKNOWN",
+  VERIFY = "VERIFY",
+  NONE = "NONE",
+}
+
+export enum FeatureSetMessageEncoding {
+  MESSAGE_ENCODING_UNKNOWN = "MESSAGE_ENCODING_UNKNOWN",
+  LENGTH_PREFIXED = "LENGTH_PREFIXED",
+  DELIMITED = "DELIMITED",
+}
+
+export enum FeatureSetJsonFormat {
+  JSON_FORMAT_UNKNOWN = "JSON_FORMAT_UNKNOWN",
+  ALLOW = "ALLOW",
+  LEGACY_BEST_EFFORT = "LEGACY_BEST_EFFORT",
+}
+
+export enum GeneratedCodeInfoAnnotationSemantic {
+  NONE = "NONE",
+  SET = "SET",
+  ALIAS = "ALIAS",
 }
 
 export type FileDescriptorSet = {
@@ -63,15 +145,16 @@ export type FileDescriptorProto = {
   name?: string
   package?: string
   dependency?: string[]
-  publicDependency?: number[]
-  weakDependency?: number[]
-  messageType?: DescriptorProto[]
-  enumType?: EnumDescriptorProto[]
+  public_dependency?: number[]
+  weak_dependency?: number[]
+  message_type?: DescriptorProto[]
+  enum_type?: EnumDescriptorProto[]
   service?: ServiceDescriptorProto[]
   extension?: FieldDescriptorProto[]
   options?: FileOptions
-  sourceCodeInfo?: SourceCodeInfo
+  source_code_info?: SourceCodeInfo
   syntax?: string
+  edition?: Edition
 }
 
 export type DescriptorProtoExtensionRange = {
@@ -89,17 +172,28 @@ export type DescriptorProto = {
   name?: string
   field?: FieldDescriptorProto[]
   extension?: FieldDescriptorProto[]
-  nestedType?: DescriptorProto[]
-  enumType?: EnumDescriptorProto[]
-  extensionRange?: DescriptorProtoExtensionRange[]
-  oneofDecl?: OneofDescriptorProto[]
+  nested_type?: DescriptorProto[]
+  enum_type?: EnumDescriptorProto[]
+  extension_range?: DescriptorProtoExtensionRange[]
+  oneof_decl?: OneofDescriptorProto[]
   options?: MessageOptions
-  reservedRange?: DescriptorProtoReservedRange[]
-  reservedName?: string[]
+  reserved_range?: DescriptorProtoReservedRange[]
+  reserved_name?: string[]
+}
+
+export type ExtensionRangeOptionsDeclaration = {
+  number?: number
+  full_name?: string
+  type?: string
+  reserved?: boolean
+  repeated?: boolean
 }
 
 export type ExtensionRangeOptions = {
-  uninterpretedOption?: UninterpretedOption[]
+  uninterpreted_option?: UninterpretedOption[]
+  declaration?: ExtensionRangeOptionsDeclaration[]
+  features?: FeatureSet
+  verification?: ExtensionRangeOptionsVerificationState
 }
 
 export type FieldDescriptorProto = {
@@ -107,13 +201,13 @@ export type FieldDescriptorProto = {
   number?: number
   label?: FieldDescriptorProtoLabel
   type?: FieldDescriptorProtoType
-  typeName?: string
+  type_name?: string
   extendee?: string
-  defaultValue?: string
-  oneofIndex?: number
-  jsonName?: string
+  default_value?: string
+  oneof_index?: number
+  json_name?: string
   options?: FieldOptions
-  proto3Optional?: boolean
+  proto3_optional?: boolean
 }
 
 export type OneofDescriptorProto = {
@@ -130,8 +224,8 @@ export type EnumDescriptorProto = {
   name?: string
   value?: EnumValueDescriptorProto[]
   options?: EnumOptions
-  reservedRange?: EnumDescriptorProtoEnumReservedRange[]
-  reservedName?: string[]
+  reserved_range?: EnumDescriptorProtoEnumReservedRange[]
+  reserved_name?: string[]
 }
 
 export type EnumValueDescriptorProto = {
@@ -148,43 +242,57 @@ export type ServiceDescriptorProto = {
 
 export type MethodDescriptorProto = {
   name?: string
-  inputType?: string
-  outputType?: string
+  input_type?: string
+  output_type?: string
   options?: MethodOptions
-  clientStreaming?: boolean
-  serverStreaming?: boolean
+  client_streaming?: boolean
+  server_streaming?: boolean
 }
 
 export type FileOptions = {
-  javaPackage?: string
-  javaOuterClassname?: string
-  javaMultipleFiles?: boolean
-  javaGenerateEqualsAndHash?: boolean
-  javaStringCheckUtf8?: boolean
-  optimizeFor?: FileOptionsOptimizeMode
-  goPackage?: string
-  ccGenericServices?: boolean
-  javaGenericServices?: boolean
-  pyGenericServices?: boolean
-  phpGenericServices?: boolean
+  java_package?: string
+  java_outer_classname?: string
+  java_multiple_files?: boolean
+  java_generate_equals_and_hash?: boolean
+  java_string_check_utf8?: boolean
+  optimize_for?: FileOptionsOptimizeMode
+  go_package?: string
+  cc_generic_services?: boolean
+  java_generic_services?: boolean
+  py_generic_services?: boolean
   deprecated?: boolean
-  ccEnableArenas?: boolean
-  objcClassPrefix?: string
-  csharpNamespace?: string
-  swiftPrefix?: string
-  phpClassPrefix?: string
-  phpNamespace?: string
-  phpMetadataNamespace?: string
-  rubyPackage?: string
-  uninterpretedOption?: UninterpretedOption[]
+  cc_enable_arenas?: boolean
+  objc_class_prefix?: string
+  csharp_namespace?: string
+  swift_prefix?: string
+  php_class_prefix?: string
+  php_namespace?: string
+  php_metadata_namespace?: string
+  ruby_package?: string
+  features?: FeatureSet
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type MessageOptions = {
-  messageSetWireFormat?: boolean
-  noStandardDescriptorAccessor?: boolean
+  message_set_wire_format?: boolean
+  no_standard_descriptor_accessor?: boolean
   deprecated?: boolean
-  mapEntry?: boolean
-  uninterpretedOption?: UninterpretedOption[]
+  map_entry?: boolean
+  deprecated_legacy_json_field_conflicts?: boolean
+  features?: FeatureSet
+  uninterpreted_option?: UninterpretedOption[]
+}
+
+export type FieldOptionsEditionDefault = {
+  edition?: Edition
+  value?: string
+}
+
+export type FieldOptionsFeatureSupport = {
+  edition_introduced?: Edition
+  edition_deprecated?: Edition
+  deprecation_warning?: string
+  edition_removed?: Edition
 }
 
 export type FieldOptions = {
@@ -192,59 +300,94 @@ export type FieldOptions = {
   packed?: boolean
   jstype?: FieldOptionsJSType
   lazy?: boolean
-  unverifiedLazy?: boolean
+  unverified_lazy?: boolean
   deprecated?: boolean
   weak?: boolean
-  uninterpretedOption?: UninterpretedOption[]
+  debug_redact?: boolean
+  retention?: FieldOptionsOptionRetention
+  targets?: FieldOptionsOptionTargetType[]
+  edition_defaults?: FieldOptionsEditionDefault[]
+  features?: FeatureSet
+  feature_support?: FieldOptionsFeatureSupport
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type OneofOptions = {
-  uninterpretedOption?: UninterpretedOption[]
+  features?: FeatureSet
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type EnumOptions = {
-  allowAlias?: boolean
+  allow_alias?: boolean
   deprecated?: boolean
-  uninterpretedOption?: UninterpretedOption[]
+  deprecated_legacy_json_field_conflicts?: boolean
+  features?: FeatureSet
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type EnumValueOptions = {
   deprecated?: boolean
-  uninterpretedOption?: UninterpretedOption[]
+  features?: FeatureSet
+  debug_redact?: boolean
+  feature_support?: FieldOptionsFeatureSupport
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type ServiceOptions = {
+  features?: FeatureSet
   deprecated?: boolean
-  uninterpretedOption?: UninterpretedOption[]
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type MethodOptions = {
   deprecated?: boolean
-  idempotencyLevel?: MethodOptionsIdempotencyLevel
-  uninterpretedOption?: UninterpretedOption[]
+  idempotency_level?: MethodOptionsIdempotencyLevel
+  features?: FeatureSet
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type UninterpretedOptionNamePart = {
-  namePart?: string
-  isExtension?: boolean
+  name_part?: string
+  is_extension?: boolean
 }
 
 export type UninterpretedOption = {
   name?: UninterpretedOptionNamePart[]
-  identifierValue?: string
-  positiveIntValue?: string
-  negativeIntValue?: string
-  doubleValue?: number
-  stringValue?: Uint8Array
-  aggregateValue?: string
+  identifier_value?: string
+  positive_int_value?: string
+  negative_int_value?: string
+  double_value?: number
+  string_value?: Uint8Array
+  aggregate_value?: string
+}
+
+export type FeatureSet = {
+  field_presence?: FeatureSetFieldPresence
+  enum_type?: FeatureSetEnumType
+  repeated_field_encoding?: FeatureSetRepeatedFieldEncoding
+  utf8_validation?: FeatureSetUtf8Validation
+  message_encoding?: FeatureSetMessageEncoding
+  json_format?: FeatureSetJsonFormat
+}
+
+export type FeatureSetDefaultsFeatureSetEditionDefault = {
+  edition?: Edition
+  overridable_features?: FeatureSet
+  fixed_features?: FeatureSet
+}
+
+export type FeatureSetDefaults = {
+  defaults?: FeatureSetDefaultsFeatureSetEditionDefault[]
+  minimum_edition?: Edition
+  maximum_edition?: Edition
 }
 
 export type SourceCodeInfoLocation = {
   path?: number[]
   span?: number[]
-  leadingComments?: string
-  trailingComments?: string
-  leadingDetachedComments?: string[]
+  leading_comments?: string
+  trailing_comments?: string
+  leading_detached_comments?: string[]
 }
 
 export type SourceCodeInfo = {
@@ -253,9 +396,10 @@ export type SourceCodeInfo = {
 
 export type GeneratedCodeInfoAnnotation = {
   path?: number[]
-  sourceFile?: string
+  source_file?: string
   begin?: number
   end?: number
+  semantic?: GeneratedCodeInfoAnnotationSemantic
 }
 
 export type GeneratedCodeInfo = {


### PR DESCRIPTION
…` option turned on

See https://github.com/llmariner/inference-manager/pull/596#issue-2875308951 for the reason.

Followed the same steps as https://github.com/llmariner/api-usage/pull/49#discussion_r1969798711.